### PR TITLE
feat: Extend linter to be able to supply tslint options

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -4,18 +4,19 @@ const chalk = require('chalk');
 
 process.stdout.write(chalk.cyan('[tslint-plugin] Starting linter in separate process...\n'));
 
-const files = JSON.parse(process.argv[2]) || [];
+const options = JSON.parse(process.argv[2]) || {};
 
-if (!files.length) {
+if (!options.files.length) {
   process.stdout.write(chalk.yellow.bold('\n[tslint-plugin] Incorrect `files` argument.\n\n'));
   process.exit();
 }
 
-const runner = new Runner({
-  files,
+const runnerOptions = Object.assign({
   format: 'custom',
   formattersDirectory: path.join(__dirname, 'formatters')
-}, process.stdout);
+}, options);
+
+const runner = new Runner(runnerOptions, process.stdout);
 
 runner.run(() => {
   process.stdout.write(chalk.green('[tslint-plugin] Linting complete.\n'));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -20,12 +20,10 @@ function apply(options, compiler) {
       return;
     }
 
-    if (!Array.isArray(files)) {
-      files = [files];
-    }
+    options.files = Array.isArray(files) ? files : [files];
 
     // Spawn a child process to run the linter
-    linterProcess = fork(path.resolve(__dirname, 'linter.js'), [JSON.stringify(files)]);
+    linterProcess = fork(path.resolve(__dirname, 'linter.js'), [JSON.stringify(options)]);
 
     // Clean up the linterProcess when finished
     linterProcess.once('exit', () => delete linterProcess);


### PR DESCRIPTION
The entire tslint options object is now passed down to the forked child process.

This allows specifying [runner options](https://github.com/palantir/tslint/blob/master/src/runner.ts) like typeCheck which is required by a few of the linting rules.