### PR TITLE
More detailed errors

### DIFF
--- a/src/linter.js
+++ b/src/linter.js
@@ -38,4 +38,6 @@ runLinter(runnerOptions, process.stdout)
   .then(() => {
     process.stdout.write(chalk.green('[tslint-plugin] Linting complete.\n'));
     process.exit();
+  }).catch(error => {
+    process.stdout.write(chalk.red(`[tslint-plugin] Error starting linter: ${error}\n${error.stack}\n`));
   });


### PR DESCRIPTION
The plugin doesn't currently provide a lot of details when the linter itself fails. I had an issue after upgrading tslinter where all of a sudden I got an error about `UnhandledPromiseRejectionWarning`. It did also say `TypeError: Cannot read property 'map' of undefined` but that wasn't very helpful either. It's only after adding the stack trace to the error message that I saw it was failing on `exclude` being `undefined` in the options. 