### PR TITLE
Typings: Prefer a namespace over declare module 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,5 @@ declare namespace TslintWebpackPlugin {
     interface Options extends Omit<TslintOptions, keyof OmittedOptions> {
         files: string | string[];
         exclude?: string[];
-        format?: string;
     }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,13 @@
-declare module "tslint-webpack-plugin" {
-    import { Plugin } from "webpack";
-    import { Options as TslintOptions } from "tslint/lib/runner";
+import { Plugin } from "webpack";
+import { Options as TslintOptions } from "tslint/lib/runner";
 
+export = TslintWebpackPlugin;
+
+declare class TslintWebpackPlugin extends Plugin {
+    constructor(options?: TslintWebpackPlugin.Options);
+}
+
+declare namespace TslintWebpackPlugin {
     // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9f4c75126167d0d8af759f58405d53d983e94ad0/types/react-redux/index.d.ts#L33-L34
     type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
     type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
@@ -17,10 +23,4 @@ declare module "tslint-webpack-plugin" {
         exclude?: string[];
         format?: string;
     }
-
-    class TslintWebpackPlugin extends Plugin {
-        constructor(options?: Options);
-    }
-
-    export = TslintWebpackPlugin;
 }


### PR DESCRIPTION
Sorry for the trouble, but I just learned that [the `import * as alias from "name"` syntax does not work with `export =` function without namespaces](https://github.com/Microsoft/TypeScript#5073) when I tried to use this in another project. The original project where I introduced this, is using the [`import alias = require("name")`](https://www.typescriptlang.org/docs/handbook/namespaces.html#aliases) syntax and it worked fine.

So, I copied the structure from [`html-webpack-plugin`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3d5138fc4bad7aea4a1a49f85e113717901261dc/types/html-webpack-plugin/index.d.ts) and now it seems to work better.

I also removed the `format`, which seems to be included in [`TslintOptions`](https://github.com/palantir/tslint/blob/235561e411c58ecbd4d96844fae28e998f0ccbda/src/runner.ts#L65) already.