### PR TITLE
fix: Use lowercase for ruleSeverity

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -132,7 +132,7 @@ function apply(options, compiler) {
           for (let r of result.out) {
             const msg = `${r.name}:${r.startPosition.line + 1}:${r.startPosition.character + 1} [tslint] ${r.ruleName}: ${r.failure}`;
 
-            if (r.ruleSeverity === 'ERROR' || options.warningsAsError) {
+            if (r.ruleSeverity === 'error' || options.warningsAsError) {
               process.stderr.write(chalk.red(msg + '\n'));
             } else {
               process.stdout.write(chalk.yellow(msg + '\n'));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -104,7 +104,7 @@ function apply(options, compiler) {
         for (let r of result.out) {
           const msg = `${r.name}:${r.startPosition.line + 1}:${r.startPosition.character + 1} [tslint] ${r.ruleName}: ${r.failure}`;
 
-          if (r.ruleSeverity === 'ERROR' || options.warningsAsError) {
+          if (r.ruleSeverity === 'error' || options.warningsAsError) {
             compilation.errors.push(createError(msg));
           } else {
             compilation.warnings.push(createError(msg));


### PR DESCRIPTION
In tslint rule severity is lowercase, so the comparison in the plugin would never be true, and we end up with only errors or only warnings (but not a mix) depending on the value of `options.warningsAsError`.
